### PR TITLE
feat: Add getTableData function to supabase client

### DIFF
--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -32,6 +32,19 @@ export async function getTableColumns(tableName: string) {
   return data.map(column => column.column_name);
 }
 
+export async function getTableData(tableName: string) {
+  const { data, error } = await supabase
+    .from(tableName)
+    .select('*');
+
+  if (error) {
+    console.error(`Error fetching data from table ${tableName}:`, error);
+    return null;
+  }
+
+  return data;
+}
+
 export async function getDocumentsToSign() {
   const { data, error } = await supabase
     .from('documents_to_sign')

--- a/src/pages/admin/documents/HistoryPage.tsx
+++ b/src/pages/admin/documents/HistoryPage.tsx
@@ -18,7 +18,6 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { useEffect, useState } from "react";
 import { getTableData, getTableColumns } from "@/lib/supabase";
 import { useParams } from "react-router-dom";
-import { useEffect, useState } from "react";
 import { DataTable } from "@/components/ui/data-table";
 import { ColumnDef } from "@tanstack/react-table";
 


### PR DESCRIPTION
This commit introduces the `getTableData` function to the supabase client library. This function allows fetching all data from a specified table.

This commit also fixes an issue in `HistoryPage.tsx` where `useEffect` and `useState` were imported twice.